### PR TITLE
Add `-` as word character to `string`s and opt-in to `tailwindcss-language-server`

### DIFF
--- a/languages/scala/config.toml
+++ b/languages/scala/config.toml
@@ -13,3 +13,7 @@ brackets = [
     { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] }
 ]
 collapsed_placeholder = " /* ... */ "
+
+[overrides.string]
+word_characters = ["-"]
+opt_into_language_servers = ["tailwindcss-language-server"]


### PR DESCRIPTION


This fixes the problem of `-` not being treated as a word-character in strings when using `tailwindcss-language-server` with Scala. See here: https://github.com/zed-industries/zed/pull/11858#issuecomment-2114796908