### PR TITLE
Fix support for tailwindcss-language-server

### DIFF
--- a/languages/scala/config.toml
+++ b/languages/scala/config.toml
@@ -13,6 +13,7 @@ brackets = [
     { start = "/*", end = " */", close = true, newline = false, not_in = ["comment", "string"] }
 ]
 collapsed_placeholder = " /* ... */ "
+scope_opt_in_language_servers = ["tailwindcss-language-server"]
 
 [overrides.string]
 word_characters = ["-"]

--- a/languages/scala/overrides.scm
+++ b/languages/scala/overrides.scm
@@ -1,0 +1,12 @@
+[
+  (symbol_literal)
+  (string)
+  (character_literal)
+  (interpolated_string_expression)
+] @string
+
+[
+  (comment)
+  (block_comment)
+  "_end_ident"
+] @comment


### PR DESCRIPTION
Turns out that #6 was missing two things:

- We need the `scope_opt_in_language_servers` field so we can opt-in to `tailwindcss-language-server` in certain scopes.
- The `overrides` work in a scope that has to be _captured_. In `overrides.string` the `string` is not the name of a syntactic node, but a tree-sitter capture variable. That means we need the `overrides.scm` file in which we capture all strings as `@string`. For some reason that's not 100% clear to me yet, we also need to add the other scopes that are used in the brackets configuration to the overrides. There's a specific piece of code in Zed that checks for this.

Sorry @ckipp01, we need a release for that again!

But the good news is that once this is merged and a new version released, the Tailwind server then works in Zed, even with `-` in completion names:

https://github.com/scalameta/metals-zed/assets/1185253/3d2857cd-8feb-4199-9217-56700063252a

Thanks to @nguyenyou's comment here: https://github.com/scalameta/metals-zed/pull/6#issuecomment-2116591990
