### PR TITLE
Update extension API to 0.0.6, add workspace configuration support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ license = "Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.4"
+zed_extension_api = "0.0.6"

--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@ A Scala extension for Zed (powered by Metals)
 * Install Metals: `cs install metals`
 
 Note: You need to have the path to `metals` exported at shell init (e.g. by an entry in `~/.bashrc`), as `zed` does not currently seem to pick up exported environment variables when started from a terminal. So it's not enough to `export PATH="$PATH:~/.local/share/coursier/bin"` in a shell and run `zed` from there. It will fail to start Metals in that case (and will not say so in the LSP log; but nothing but syntax highlighting will work then).
+
+## Configuration
+
+You can set [Metals user configuration settings](https://scalameta.org/metals/docs/integrations/new-editor/#metals-user-configuration)
+in your zed settings.json in `lsp.metals.settings`. For example, to enable displaying type annotations for inferred types
+as inlay hints:
+
+``` json
+{
+  "lsp": {
+    "metals": {
+      "settings": {
+        "inlayHints": {
+          "inferredTypes": {
+            "enable": true
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use zed_extension_api::{self as zed, Result};
+use zed_extension_api::{self as zed, serde_json, settings::LspSettings, Result};
 
 struct ScalaExtension;
 
@@ -9,7 +9,7 @@ impl zed::Extension for ScalaExtension {
 
     fn language_server_command(
         &mut self,
-        _config: zed::LanguageServerConfig,
+        _language_server_id: &zed::LanguageServerId,
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         let path = worktree
@@ -21,6 +21,21 @@ impl zed::Extension for ScalaExtension {
             args: vec![],
             env: Default::default(),
         })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree("metals", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+
+        Ok(Some(serde_json::json!({
+            "metals": settings
+        })))
     }
 }
 


### PR DESCRIPTION
This makes it possible to enable inlay hints. Example configuration added to `README.md` (setting `"inlayHints.inferredTypes.enable": false` does not seem to work, the nested objects are required).

![2024-07-14T16:27:03,557117547+02:00](https://github.com/user-attachments/assets/71d0f0c0-af7e-43a1-b68d-5935d70f0909)
