### PR TITLE
Metals configuration enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ Cargo.lock
 *.pdb
 .DS_Store
 *.wasm
+
+# Ignore build-generated grammars folder
+grammars

--- a/README.md
+++ b/README.md
@@ -28,3 +28,27 @@ as inlay hints:
   }
 }
 ```
+
+You can also set [Metals initialization options](https://scalameta.org/metals/docs/integrations/new-editor/#initializationoptions) and
+[Metals server properties](https://scalameta.org/metals/docs/integrations/new-editor#metals-server-properties) in your zed settings.json
+in `lsp.metals.binary.arguments` and `lsp.metals.initialization_options`, respectively.
+
+For example, to [enable HTTP server](https://scalameta.org/metals/docs/integrations/new-editor#metals-http-client) (running on http://localhost:5031 by default)
+for executing client commands, which currently are not supported by zed directly, you can use:
+
+``` json
+{
+  "lsp": {
+    "metals": {
+      "binary": {
+        "arguments": [
+          "-Dmetals.http=on"
+        ]
+      },
+      "initialization_options": {
+        "isHttpEnabled": true
+      }
+    }
+  }
+}
+```

--- a/extension.toml
+++ b/extension.toml
@@ -16,4 +16,4 @@ language = "Scala"
 
 [grammars.scala]
 repository = "https://github.com/tree-sitter/tree-sitter-scala"
-commit = "45b5ba0e749a8477a8fd2666f082f352859bdc3c"
+commit = "d9017869dda79cefe2dc9d23c6125eda0a2d5d22"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,32 @@ impl zed::Extension for ScalaExtension {
             .which("metals")
             .ok_or_else(|| "Metals must be installed via coursier. Please install coursier (https://get-coursier.io/), and then run `cs install metals`.".to_string())?;
 
+        let arguments = LspSettings::for_worktree("metals", worktree)
+            .map(|lsp_settings| {
+                lsp_settings
+                    .binary
+                    .and_then(|binary| binary.arguments)
+                    // If no arguments are provided, default to enabling the HTTP server.
+                    .unwrap_or(vec!["-Dmetals.http=on".to_string()])
+            })
+            .unwrap_or_default();
+
         Ok(zed::Command {
             command: path,
-            args: vec![],
+            args: arguments,
             env: worktree.shell_env(),
         })
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        _language_server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let initialization_options = LspSettings::for_worktree("metals", worktree)
+            .map(|lsp_settings| lsp_settings.initialization_options.clone());
+
+        initialization_options
     }
 
     fn language_server_workspace_configuration(


### PR DESCRIPTION
The following changes allow to configure initial_options and server properties of Metals, and enable metals.http by default. This change launches the Metal's HTTP server on http://localhost:5031 which exposes Metals custom commands, so you don't have to launch VS Code every time you need to switch BSP server.

Also, it is possible to enable Metals' "best effort compilation" for Scala 3.5.0 by setting the argument in Zed's settings:

```json
{
  ...
  "lsp": {
    "metals": {
      "binary": {
        "arguments": ["-Dmetals.http=on", "-Dmetals.enable-best-effort=true"]
      },
   ...
  }
}
```

There are 2 more unrelated tiny commits I'm lazy to split into separate PRs, will do if necessary. - adding `grammars` folder to ignore list, as it is generated by the compilation and updating to newer tree-sitter-scala version.