### PR TITLE
Use number highlight for floating point literals

### DIFF
--- a/languages/scala/highlights.scm
+++ b/languages/scala/highlights.scm
@@ -126,7 +126,7 @@
 
 (boolean_literal) @boolean
 (integer_literal) @number
-(floating_point_literal) @float
+(floating_point_literal) @number
 
 [
   (symbol_literal)


### PR DESCRIPTION
Fixing https://github.com/scalameta/metals-zed/issues/10 by replacing a 'number' highlight instead of 'float'.

<img width="570" alt="Snímek obrazovky 2024-08-27 v 15 25 13" src="https://github.com/user-attachments/assets/c480a0fa-cd30-4750-ab3d-4406224f9e8a">
