### PR TITLE
Add highlights to the completions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@ impl zed::Extension for ScalaExtension {
             | CompletionKind::Class
             | CompletionKind::Interface
             | CompletionKind::Module => "class ",
+            CompletionKind::Variable => "var ",
             CompletionKind::Field
-            | CompletionKind::Variable
             | CompletionKind::Constant
             | CompletionKind::Value
             | CompletionKind::Property => "val ",
@@ -106,8 +106,8 @@ impl zed::Extension for ScalaExtension {
             | SymbolKind::Interface
             | SymbolKind::Constructor => "class ",
             SymbolKind::Method | SymbolKind::Function => "def ",
-            SymbolKind::Property => todo!(),
-            SymbolKind::Field | SymbolKind::Variable | SymbolKind::Constant => "val ",
+            SymbolKind::Variable => "var ",
+            SymbolKind::Property | SymbolKind::Field | SymbolKind::Constant => "val ",
             _ => "",
         };
         let name = symbol.name;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
-use zed_extension_api::{self as zed, serde_json, settings::LspSettings, Result};
+use zed_extension_api::{
+    self as zed,
+    lsp::{Completion, CompletionKind, Symbol, SymbolKind},
+    serde_json,
+    settings::LspSettings,
+    CodeLabel, CodeLabelSpan, Result,
+};
 
 struct ScalaExtension;
 
@@ -57,6 +63,61 @@ impl zed::Extension for ScalaExtension {
         Ok(Some(serde_json::json!({
             "metals": settings
         })))
+    }
+
+    fn label_for_completion(
+        &self,
+        _language_server_id: &zed_extension_api::LanguageServerId,
+        completion: Completion,
+    ) -> Option<zed_extension_api::CodeLabel> {
+        let prefix = match completion.kind? {
+            CompletionKind::Method | CompletionKind::Function => "def ",
+            CompletionKind::Constructor
+            | CompletionKind::Class
+            | CompletionKind::Interface
+            | CompletionKind::Module => "class ",
+            CompletionKind::Field
+            | CompletionKind::Variable
+            | CompletionKind::Constant
+            | CompletionKind::Value
+            | CompletionKind::Property => "val ",
+            CompletionKind::Enum => "enum ",
+            CompletionKind::Keyword => "",
+            _ => return None,
+        };
+        let name = completion.label;
+        let code = format!("{prefix}{name}");
+        let code_len = code.len();
+        Some(CodeLabel {
+            code,
+            spans: vec![CodeLabelSpan::code_range(prefix.len()..code_len)],
+            filter_range: (0..name.len()).into(),
+        })
+    }
+
+    fn label_for_symbol(
+        &self,
+        _language_server_id: &zed_extension_api::LanguageServerId,
+        symbol: Symbol,
+    ) -> Option<CodeLabel> {
+        let prefix = match symbol.kind {
+            SymbolKind::Module
+            | SymbolKind::Class
+            | SymbolKind::Interface
+            | SymbolKind::Constructor => "class ",
+            SymbolKind::Method | SymbolKind::Function => "def ",
+            SymbolKind::Property => todo!(),
+            SymbolKind::Field | SymbolKind::Variable | SymbolKind::Constant => "val ",
+            _ => "",
+        };
+        let name = symbol.name;
+        let code = format!("{prefix}{name}");
+        let code_len = code.len();
+        Some(CodeLabel {
+            code,
+            spans: vec![CodeLabelSpan::code_range(prefix.len()..code_len)],
+            filter_range: (0..name.len()).into(),
+        })
     }
 }
 


### PR DESCRIPTION
Adds `label_for_completion` and `label_for_symbol` which allow Zed to highlight symbols when searching or when using auto completion
<img width="1192" alt="Screenshot 2024-10-09 at 16 49 30" src="https://github.com/user-attachments/assets/82960593-a191-4d8c-a5e4-16e7cc4d87f3">
