### PR TITLE
Add entry point detection

### DIFF
--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -12,3 +12,15 @@
     )
     (#set! tag scala-main)
 )
+
+(
+    (
+        (object_definition
+            extend: (extends_clause
+                type: (type_identifier) @run
+            )
+        ) @_scala_app_object_end
+        (#eq? @run "App")
+    )
+    (#set! tag scala-main)
+)

--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -1,0 +1,14 @@
+(
+    (
+        (function_definition
+            (annotation
+                name: (type_identifier) @run
+            )
+            name: _
+            parameters: _
+            body: _
+        ) @_scala_main_function_end
+        (#eq? @run "main")
+    )
+    (#set! tag scala-main)
+)

--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -24,3 +24,18 @@
     )
     (#set! tag scala-main)
 )
+
+(
+    (
+        (object_definition
+            name: _
+            body: (template_body
+                (function_definition
+                    name: (identifier) @run
+                ) @_jvm_main_function_end
+            )
+        )
+        (#eq? @run "main")
+    )
+    (#set! tag scala-main)
+)


### PR DESCRIPTION
This adds support for runnables, which allows writing tasks like this:
```json
[
  {
    "label": "Scala run",
    "command": "scala-cli $ZED_FILE",
    "tags": ["scala-main"]
  }
]
```
