### PR TITLE
feat: add support for test runner with scala-test

### DIFF
--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -39,3 +39,15 @@
     )
     (#set! tag scala-main)
 )
+
+(
+    (
+        (class_definition
+            extend: (extends_clause
+                type: (type_identifier) @run
+            )
+        ) @_scala_test_class_end
+        (#match? @run "^(AnyWordSpec|WordSpec|AnyFunSpec|FunSpec|AnyFunSuite|FunSuite|AnyFlatSpec|FlatSpec|FeatureSpec|AnyFeatureSpec|AnyPropSpec|PropSpec|AnyFreeSpec|FreeSpec)$")
+    )
+    (#set! tag scala-test)
+)


### PR DESCRIPTION
Hi there 👋

I'm not sure if it's the appropriate way to do it, but I wanted to run the tests from within ZED and got it working using the query in this commit. (Here's a video showing it in action: [https://www.loom.com/share/f3c286309e064774a7a8872b5b68a99e](https://www.loom.com/share/f3c286309e064774a7a8872b5b68a99e))

This is my tasks.json
```json
[
  {
    "label": "run tests with bloop",
    "name": "run-bloop-test",
    "command": "./run-bloop-test.sh ${ZED_WORKTREE_ROOT} ${ZED_FILE}",
    "working_directory": "${workspace_root}",
    "environment": {
      "PATH": "${env.PATH}"
    },
    "keystroke": "cmd-shift-r",
    "tags": ["scala-test"]
  }
]
```

And the run-bloop-test.sh script:
I've haven't added guards or proper opt parsing or anything, I just wanted to hack my way around running the tests from zed:

```bash
#!/bin/bash

project_name=$(basename $1)
filename=$(basename $2 | sed 's/\.scala//')
bloop test $project_name -o "*$filename*"
```

