### PR TITLE
chore: add documentation on how to release the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,10 @@ package_name=$(cat $filepath | grep -E '^package ' | sed 's/package //') # Extra
 
 bloop run $project_name -m "$package_name.$mainname"
 ```
+
+## Releasing the extension
+To release the extension, you need to bump the version in `Cargo.toml` and `extension.toml` in the root of the repository and create a tag for the version (example bump: e8b826cb3fc0f5f054aa0012e17824f8904a73f5).
+
+After that, you need to open up a PR on [zed-industries/extensions](https://github.com/zed-industries/extensions) (example: [zed-industries/extensions#29](https://github.com/zed-industries/extensions/pull/1609/files), the PR must :
+- Update the submodule on extensions/scala to the appropriate commit
+- Update the file `extensions.toml` to set the appropriate version for the extension in the `[scala]` section


### PR DESCRIPTION
The commit SHA should be replaced properly by a link to the commit once merged, as per [github documentation](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#commit-shas)