### PR TITLE
Include Cats/ZIO common runnables

### DIFF
--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -25,6 +25,32 @@
     (#set! tag scala-main)
 )
 
+;Common Runnables for Cats Effect
+(
+    (
+        (object_definition
+            extend: (extends_clause
+                type: (type_identifier) @run
+            )
+        ) @_scala_app_object_end
+        (#match? @run "^IOApp?\.Simple")
+    )
+    (#set! tag scala-main)
+)
+
+;Common Runnables for ZIO
+(
+    (
+        (object_definition
+            extend: (extends_clause
+                type: (type_identifier) @run
+            )
+        ) @_scala_app_object_end
+        (#match? @run "^ZIOApp?(Default)")
+    )
+    (#set! tag scala-main)
+)
+
 (
     (
         (object_definition


### PR DESCRIPTION
Not sure if you'd like it all in one block - but I split the blocks to make it clear which ecosystem it was in support for.

I used the "App" block as an example, as I'm not too familiar with Scheme.

Let me know if this is okay - I'm not exactly sure how best to verify that this works as expected.

resolves #37 