### PR TITLE
Add Support For Other Test Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,16 @@ For Munit Extensions:
 - TapirGoldenOpenAPISuite
 - TapirGoldenOpenAPIValidatorSuite
 
+For Hedgehog:
+- Properties
+
 For Weaver Test:
 - SimpleIOSuite / IOSuite
 
 For ZIO Test:
 - ZIOSpecDefault
 
+If your favorite test framework is not included, or more traits are have been added, please update the `runnables.scm` file found in the `languages/scala` directory
 
 In order to get the run icon in the gutter, you need to provide zed with a task that run the test class.
 

--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -66,7 +66,7 @@
     (#set! tag scala-main)
 )
 
-; ScalaTest Common Runnables
+; ScalaTest Common Runnables - https://www.scalatest.org/
 (
     (
         (class_definition
@@ -127,6 +127,19 @@
             )
         ) @_scala_test_class_end
         (#match? @run "^((test\\.)?ZIOSpecDefault)$")
+    )
+    (#set! tag scala-test)
+)
+
+; Hedgehog - https://hedgehogqa.github.io/scala-hedgehog/
+(
+    (
+        (class_definition
+            extend: (extends_clause
+                type: (type_identifier) @run
+            )
+        ) @_scala_test_class_end
+        (#match? @run "^Properties$")
     )
     (#set! tag scala-test)
 )


### PR DESCRIPTION
This PR adds support for other testing frameworks outside of ScalaTest. I tried to be comprehensive but I can include others in this PR as long as there is a link.

resolves #36 