### PR TITLE
Bump version to 0.1.2 for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_scala"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 publish = false
 license = "Apache-2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "scala"
 name = "Scala"
 description = "Scala support."
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = [
     "Igal Tabachnik <hmemcpy@gmail.com>",


### PR DESCRIPTION
Per previous comment - this bumps the version to 0.1.2 to allow for the new test framework features