### PR TITLE
feat: Implement initial Metals DAP support for Zed

### DIFF
--- a/debug_adapter_schemas/metals-dap.json
+++ b/debug_adapter_schemas/metals-dap.json
@@ -1,0 +1,87 @@
+{
+  "type": "object",
+  "title": "Metals DAP Configuration",
+  "properties": {
+    "label": {
+      "type": "string",
+      "description": "Display name for this configuration."
+    },
+    "adapter": {
+      "type": "string",
+      "description": "Adapter type, should be 'metals-dap'.",
+      "const": "metals-dap"
+    },
+    "request": {
+      "type": "string",
+      "description": "The request type of this launch configuration. Valid values are 'launch' and 'attach'.",
+      "enum": ["launch", "attach"]
+    },
+    "program": {
+      "type": "string",
+      "description": "Path to the program to debug. Can be used as mainClass if mainClass is not specified."
+    },
+    "mainClass": {
+      "type": "string",
+      "description": "The fully qualified name of the main class to run."
+    },
+    "testClass": {
+      "type": "string",
+      "description": "The fully qualified name of the test class to run."
+    },
+    "args": {
+      "type": "array",
+      "description": "Command line arguments passed to the program.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "cwd": {
+      "type": "string",
+      "description": "Current working directory of the program."
+    },
+    "jvmOptions": {
+      "type": ["array", "string"],
+      "description": "JVM options. Can be an array of strings or a single space-separated string.",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "buildTarget": {
+      "type": "string",
+      "description": "The build target name (e.g., sbt project name)."
+    },
+    "processId": {
+      "type": ["integer", "string"],
+      "description": "Process ID to attach to. If specified, 'request' should be 'attach'."
+    },
+    "env": {
+        "type": "object",
+        "description": "Environment variables to pass to the program.",
+        "additionalProperties": {
+            "type": "string"
+        }
+    },
+    "build": {
+        "type": ["string", "object"],
+        "description": "Optional task to run before debugging. Can be a task label or a task definition."
+    }
+  },
+  "required": [
+    "label",
+    "adapter",
+    "request"
+  ],
+  "oneOf": [
+    { "required": ["mainClass"] },
+    { "required": ["testClass"] },
+    { "required": ["program"] }
+  ],
+  "if": {
+    "properties": { "request": { "const": "attach" } }
+  },
+  "then": {
+    "required": ["processId"]
+  }
+}

--- a/extension.toml
+++ b/extension.toml
@@ -17,3 +17,8 @@ language = "Scala"
 [grammars.scala]
 repository = "https://github.com/tree-sitter/tree-sitter-scala"
 commit = "d9017869dda79cefe2dc9d23c6125eda0a2d5d22"
+
+[debug_adapters.metals-dap]
+name = "Metals DAP"
+schema_path = "debug_adapter_schemas/metals-dap.json"
+language = "Scala"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,4 +121,246 @@ impl zed::Extension for ScalaExtension {
     }
 }
 
+use zed_extension_api::{DebugAdapterBinary, DebugTaskDefinition, StartDebuggingRequestArgumentsRequest, Worktree};
+
+impl ScalaExtension {
+    fn get_metals_dap_path(&self, worktree: &zed::Worktree) -> Result<String> {
+        worktree
+            .which("metals-dap")
+            .ok_or_else(|| "Metals DAP server (metals-dap) must be installed manually. Please ensure it is in your PATH.".to_string())
+    }
+}
+
+impl zed::Extension for ScalaExtension {
+    fn new() -> Self {
+        Self
+    }
+
+    fn language_server_command(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let path = worktree
+            .which("metals")
+            .ok_or_else(|| "Metals must be installed manually. Recommended way is to install coursier (https://get-coursier.io/), and then run `cs install metals`.".to_string())?;
+
+        let arguments = LspSettings::for_worktree("metals", worktree)
+            .map(|lsp_settings| {
+                lsp_settings
+                    .binary
+                    .and_then(|binary| binary.arguments)
+                    // If no arguments are provided, default to enabling the HTTP server.
+                    .unwrap_or(vec!["-Dmetals.http=on".to_string()])
+            })
+            .unwrap_or_default();
+
+        Ok(zed::Command {
+            command: path,
+            args: arguments,
+            env: worktree.shell_env(),
+        })
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        _language_server_id: &zed_extension_api::LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let initialization_options = LspSettings::for_worktree("metals", worktree)
+            .map(|lsp_settings| lsp_settings.initialization_options.clone());
+
+        initialization_options
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree("metals", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+
+        Ok(Some(serde_json::json!({
+            "metals": settings
+        })))
+    }
+
+    fn label_for_completion(
+        &self,
+        _language_server_id: &zed_extension_api::LanguageServerId,
+        completion: Completion,
+    ) -> Option<zed_extension_api::CodeLabel> {
+        let prefix = match completion.kind? {
+            CompletionKind::Method | CompletionKind::Function => "def ",
+            CompletionKind::Constructor
+            | CompletionKind::Class
+            | CompletionKind::Interface
+            | CompletionKind::Module => "class ",
+            CompletionKind::Variable => "var ",
+            CompletionKind::Field
+            | CompletionKind::Constant
+            | CompletionKind::Value
+            | CompletionKind::Property => "val ",
+            CompletionKind::Enum => "enum ",
+            CompletionKind::Keyword => "",
+            _ => return None,
+        };
+        let name = completion.label.replace("  ", " ").replace("\n", "");
+        let code = format!("{prefix}{name}");
+        let code_len = code.len();
+        Some(CodeLabel {
+            code,
+            spans: vec![CodeLabelSpan::code_range(prefix.len()..code_len)],
+            filter_range: (0..name.len()).into(),
+        })
+    }
+
+    fn label_for_symbol(
+        &self,
+        _language_server_id: &zed_extension_api::LanguageServerId,
+        symbol: Symbol,
+    ) -> Option<CodeLabel> {
+        let prefix = match symbol.kind {
+            SymbolKind::Module
+            | SymbolKind::Class
+            | SymbolKind::Interface
+            | SymbolKind::Constructor => "class ",
+            SymbolKind::Method | SymbolKind::Function => "def ",
+            SymbolKind::Variable => "var ",
+            SymbolKind::Property | SymbolKind::Field | SymbolKind::Constant => "val ",
+            _ => "",
+        };
+        let name = symbol.name;
+        let code = format!("{prefix}{name}");
+        let code_len = code.len();
+        Some(CodeLabel {
+            code,
+            spans: vec![CodeLabelSpan::code_range(prefix.len()..code_len)],
+            filter_range: (0..name.len()).into(),
+        })
+    }
+
+    fn get_dap_binary(
+        &mut self,
+        adapter_name: zed::DapAdapterName,
+        _config: DebugTaskDefinition,
+        _user_provided_debug_adapter_path: Option<String>,
+        worktree: &Worktree,
+    ) -> Result<DebugAdapterBinary> {
+        if adapter_name.as_ref() != "metals-dap" {
+            return Err("Unsupported debug adapter".to_string());
+        }
+
+        let dap_path = self.get_metals_dap_path(worktree)?;
+
+        // Most DAP servers communicate via stdio by default.
+        // Arguments might be needed based on how Metals DAP server is implemented.
+        // For now, we'll assume no special arguments are needed.
+        Ok(DebugAdapterBinary {
+            path: dap_path,
+            arguments: Vec::new(),
+            environment: worktree.shell_env(),
+        })
+    }
+
+    fn dap_request_kind(
+        &mut self,
+        _adapter_name: zed::DapAdapterName,
+        _config: zed_extension_api::serde_json::Value,
+    ) -> Result<StartDebuggingRequestArgumentsRequest> {
+        let config_map = match _config {
+            serde_json::Value::Object(map) => map,
+            _ => return Ok(StartDebuggingRequestArgumentsRequest::Launch), // Default to launch if not an object
+        };
+
+        if config_map.contains_key("processId") {
+            Ok(StartDebuggingRequestArgumentsRequest::Attach)
+        } else {
+            Ok(StartDebuggingRequestArgumentsRequest::Launch)
+        }
+    }
+
+    fn dap_config_to_scenario(
+        &mut self,
+        _adapter_name: zed::DapAdapterName,
+        _config: zed::DebugConfig,
+    ) -> Result<zed::DebugScenario> {
+        let mut dap_config = serde_json::Map::new();
+
+        // Common DAP fields
+        dap_config.insert("name".to_string(), serde_json::Value::String(_config.label.unwrap_or("Scala Debug".to_string())));
+        dap_config.insert("type".to_string(), serde_json::Value::String("scala".to_string()));
+        // `request` will be determined by `dap_request_kind` based on presence of `processId`
+        // but we can set a default here if not already present from a more specific rule.
+        // This might be refined later.
+        let request_type = if _config.config.contains_key("processId") { "attach" } else { "launch" };
+        dap_config.insert("request".to_string(), serde_json::Value::String(request_type.to_string()));
+
+
+        // Metals specific fields - mapping from generic DebugConfig
+        // Users will provide these in their .zed/debug.json
+        if let Some(main_class) = _config.config.get("mainClass").and_then(|v| v.as_str()) {
+            dap_config.insert("mainClass".to_string(), serde_json::Value::String(main_class.to_string()));
+        }
+
+        if let Some(test_class) = _config.config.get("testClass").and_then(|v| v.as_str()) {
+            dap_config.insert("testClass".to_string(), serde_json::Value::String(test_class.to_string()));
+        }
+
+        if let Some(program) = _config.program {
+            // If neither mainClass nor testClass is set, 'program' could potentially be used as mainClass.
+            // This assumption needs validation against how Metals DAP behaves.
+            if !dap_config.contains_key("mainClass") && !dap_config.contains_key("testClass") {
+                 dap_config.insert("mainClass".to_string(), serde_json::Value::String(program.clone()));
+            }
+            // Or, if 'program' is meant to be the path to a JAR file for execution:
+            // dap_config.insert("jar".to_string(), serde_json::Value::String(program));
+        }
+
+        if let Some(args) = _config.args {
+            dap_config.insert("args".to_string(), serde_json::Value::Array(args.into_iter().map(serde_json::Value::String).collect()));
+        }
+
+        if let Some(cwd) = _config.cwd {
+            dap_config.insert("cwd".to_string(), serde_json::Value::String(cwd));
+        }
+
+        if let Some(jvm_options) = _config.config.get("jvmOptions").and_then(|v| v.as_array()) {
+            dap_config.insert("jvmOptions".to_string(), serde_json::Value::Array(jvm_options.clone()));
+        } else if let Some(jvm_options_str) = _config.config.get("jvmOptions").and_then(|v| v.as_str()) {
+            // Handle if jvmOptions is provided as a single string
+             let options_array: Vec<serde_json::Value> = jvm_options_str.split_whitespace().map(|s| serde_json::Value::String(s.to_string())).collect();
+            dap_config.insert("jvmOptions".to_string(), serde_json::Value::Array(options_array));
+        }
+
+
+        if let Some(build_target) = _config.config.get("buildTarget").and_then(|v| v.as_str()) {
+            dap_config.insert("buildTarget".to_string(), serde_json::Value::String(build_target.to_string()));
+        }
+
+        // Handle processId for attach requests
+        if let Some(process_id) = _config.config.get("processId") {
+            dap_config.insert("processId".to_string(), process_id.clone());
+        }
+
+        // TODO: Handle environment variables (_config.env) if Metals DAP supports them.
+        // let env_map: serde_json::Map<String, serde_json::Value> = _config.env
+        //     .unwrap_or_default()
+        //     .into_iter()
+        //     .map(|(k, v)| (k, serde_json::Value::String(v)))
+        //     .collect();
+        // dap_config.insert("env".to_string(), serde_json::Value::Object(env_map));
+
+
+        Ok(zed::DebugScenario {
+            label: _config.label.unwrap_or_else(|| "Scala Debug Scenario".to_string()),
+            config: serde_json::Value::Object(dap_config),
+            build_task: _config.build, // Pass through any build task
+        })
+    }
+}
+
 zed::register_extension!(ScalaExtension);


### PR DESCRIPTION
This commit introduces initial support for debugging Scala applications with Metals DAP in Zed.

Key changes:
- Added a DAP adapter definition for `metals-dap` in `extension.toml`.
- Implemented the `get_dap_binary`, `dap_request_kind`, and `dap_config_to_scenario` methods in `src/lib.rs` to handle DAP integration.
- Created a JSON schema file (`debug_adapter_schemas/metals-dap.json`) for Metals DAP configurations.

The implementation allows users to configure launch and attach debug scenarios for Scala projects. It maps common DAP fields and Metals-specific options like `mainClass`, `testClass`, `jvmOptions`, and `buildTarget`.

Further testing in a Scala development environment with `metals-dap` installed is required to fully validate the integration.