### PR TITLE
Updating ZIO test to look for an object instead of a class.

### DIFF
--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -121,7 +121,7 @@
 ; ZIO Test - https://zio.dev/reference/test/
 (
     (
-        (class_definition
+        (object_definition
             extend: (extends_clause
                 type: (type_identifier) @run
             )


### PR DESCRIPTION
This PR makes the change that I think is needed for https://github.com/scalameta/metals-zed/issues/56.