### PR TITLE
Add `FunSuite` and `FunSuiteIO` to runnables

### DIFF
--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -118,6 +118,18 @@
     (#set! tag scala-test)
 )
 
+(
+    (
+        (object_definition
+            extend: (extends_clause
+                type: (type_identifier) @run
+            )
+        ) @_scala_test_class_end
+        (#match? @run "^(FunSuite|FunSuiteIO)$")
+    )
+    (#set! tag scala-test)
+)
+
 ; ZIO Test - https://zio.dev/reference/test/
 (
     (


### PR DESCRIPTION
Add `FunSuite` and `FunSuiteIO` from weaver as `scala-test` runnables (https://typelevel.org/weaver-test/features/funsuite.html). This should add the run icon to the gutter for those tests.

I just copy/pasted the code and did not test this so far. Is there a possibility to test this locally?

As I am not familiar with this in any way, could it conflict with the `FunSuite` from ScalaTest?