### PR TITLE
Update highlights.scm

### DIFF
--- a/languages/scala/highlights.scm
+++ b/languages/scala/highlights.scm
@@ -169,6 +169,13 @@
   "if"
   "match"
   "then"
+  "do"
+  "for"
+  "while"
+  "yield"
+  "try"
+  "catch"
+  "throw"
 ] @keyword
 
 [
@@ -206,13 +213,6 @@
  ","
 ] @punctuation.delimiter
 
-[
-  "do"
-  "for"
-  "while"
-  "yield"
-] @repeat
-
 "def" @keyword.function
 
 [
@@ -223,12 +223,6 @@
 
 ["import" "export"] @include
 
-[
-  "try"
-  "catch"
-  "throw"
-] @exception
-
 "return" @keyword.return
 
 (comment) @spell @comment
@@ -237,9 +231,9 @@
 ;; `case` is a conditional keyword in case_block
 
 (case_block
-  (case_clause ("case") @conditional))
+  (case_clause ("case") @keyword))
 (indented_cases
-  (case_clause ("case") @conditional))
+  (case_clause ("case") @keyword))
 
 (operator_identifier) @operator
 

--- a/languages/scala/highlights.scm
+++ b/languages/scala/highlights.scm
@@ -83,7 +83,7 @@
 
 (call_expression
   function: (field_expression
-    field: (identifier) @method.call))
+    field: (identifier) @function.call))
 
 ((call_expression
    function: (identifier) @constructor)
@@ -109,10 +109,10 @@
 ; method definition
 
 (function_declaration
-      name: (identifier) @method)
+      name: (identifier) @function)
 
 (function_definition
-      name: (identifier) @method)
+      name: (identifier) @function)
 
 ; expressions
 
@@ -125,7 +125,7 @@
 
 (boolean_literal) @boolean
 (integer_literal) @number
-(floating_point_literal) @float
+(floating_point_literal) @number
 
 [
   (string)
@@ -165,6 +165,10 @@
   "implicit"
   "extension"
   "with"
+  "else"
+  "if"
+  "match"
+  "then"
 ] @keyword
 
 [
@@ -187,13 +191,6 @@
 ;; special keywords
 
 "new" @keyword.operator
-
-[
-  "else"
-  "if"
-  "match"
-  "then"
-] @conditional
 
 [
  "("


### PR DESCRIPTION
There were several invalid highlight captures that are not used by Zed, such as `@method` and `@conditional`. I changed them to the appropriate ones according to [Zed documentation](https://zed.dev/docs/extensions/languages?highlight=debug%20tree-sitter#tree-sitter-queries). 
Before:
<img width="692" height="529" alt="image" src="https://github.com/user-attachments/assets/d7b9e2a1-4c21-44cb-9dd7-7c2f6fee2c1b" />

After:
<img width="692" height="529" alt="image" src="https://github.com/user-attachments/assets/57112b75-6d0b-4022-9213-d074bdf52c8d" />

There are still some captures like `(inline_modifier) @storageclass
` which are invalid, but I don't know what the appropriate capture would be there.