### PR TITLE
Update Queries for runnables and outlines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zed_scala"
 version = "0.1.5"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/extension.toml
+++ b/extension.toml
@@ -16,4 +16,4 @@ language = "Scala"
 
 [grammars.scala]
 repository = "https://github.com/tree-sitter/tree-sitter-scala"
-commit = "d9017869dda79cefe2dc9d23c6125eda0a2d5d22"
+commit = "97aead18d97708190a51d4f551ea9b05b60641c9"

--- a/languages/scala/highlights.scm
+++ b/languages/scala/highlights.scm
@@ -137,7 +137,6 @@
 (floating_point_literal) @number
 
 [
-  (symbol_literal)
   (string)
   (character_literal)
   (interpolated_string_expression)

--- a/languages/scala/indents.scm
+++ b/languages/scala/indents.scm
@@ -1,20 +1,30 @@
-[
-  (block)
-  (arguments)
-  (parameter)
-  (class_definition)
-  (trait_definition)
-  (object_definition)
-  (function_definition)
-  (val_definition)
-  (import_declaration)
-  (while_expression)
-  (do_while_expression)
-  (for_expression)
-  (try_expression)
-  (match_expression)
-] @indent
+; These indent queries adhere to nvim-tree-sytter syntax.
+; See `nvim-tree-sitter-indentation-mod` vim help page.
 
-(_ "[" "]" @end) @indent
-(_ "{" "}" @end) @indent
-(_ "(" ")" @end) @indent
+[
+  (template_body)
+  (block)
+  (parameters)
+  (arguments)
+  (match_expression)
+  (splice_expression)
+  (import_declaration)
+  (function_definition)
+  (ERROR ":")
+  (ERROR "=")
+  ("match")
+  (":")
+  ("=")
+] @indent.begin
+
+(arguments ")" @indent.end)
+
+"}" @indent.end
+
+"end" @indent.end
+
+[
+  ")"
+  "]"
+  "}"
+] @indent.branch

--- a/languages/scala/locals.scm
+++ b/languages/scala/locals.scm
@@ -1,0 +1,29 @@
+(template_body) @local.scope
+(lambda_expression) @local.scope
+
+
+(function_declaration
+      name: (identifier) @local.definition) @local.scope
+
+(function_definition
+      name: (identifier) @local.definition)
+
+(parameter
+  name: (identifier) @local.definition)
+
+(binding
+  name: (identifier) @local.definition)
+
+(val_definition
+  pattern: (identifier) @local.definition)
+
+(var_definition
+  pattern: (identifier) @local.definition)
+
+(val_declaration
+  name: (identifier) @local.definition)
+
+(var_declaration
+  name: (identifier) @local.definition)
+
+(identifier) @local.reference

--- a/languages/scala/outline.scm
+++ b/languages/scala/outline.scm
@@ -1,3 +1,7 @@
+(package_clause
+  "package" @context
+  name: (_) @name) @item
+
 (class_definition
     "class" @context
     name: (_) @name) @item
@@ -9,6 +13,10 @@
 (object_definition
     "object" @context
     name: (_) @name) @item
+
+(given_definition
+    "given" @context
+    name: (_)? @name) @item
 
 (trait_definition
     "trait" @context

--- a/languages/scala/overrides.scm
+++ b/languages/scala/overrides.scm
@@ -1,5 +1,4 @@
 [
-  (symbol_literal)
   (string)
   (character_literal)
   (interpolated_string_expression)

--- a/languages/scala/runnables.scm
+++ b/languages/scala/runnables.scm
@@ -1,11 +1,13 @@
 (
     (
+        (package_clause
+          name: (package_identifier) @scala_package_name)*
         (function_definition
             (annotation
                 name: (type_identifier) @run
             )
-            name: _
-            parameters: _
+            name: (identifier) @scala_main_function_name
+            parameters: _?
             body: _
         ) @_scala_main_function_end
         (#eq? @run "main")
@@ -15,7 +17,10 @@
 
 (
     (
+        (package_clause
+          name: (package_identifier) @scala_package_name)*
         (object_definition
+            name: (identifier) @scala_main_function_name
             extend: (extends_clause
                 type: (type_identifier) @run
             )
@@ -53,8 +58,10 @@
 
 (
     (
+        (package_clause
+          name: (package_identifier) @scala_package_name)*
         (object_definition
-            name: _
+            name: (identifier) @scala_main_function_name
             body: (template_body
                 (function_definition
                     name: (identifier) @run

--- a/languages/scala/tags.scm
+++ b/languages/scala/tags.scm
@@ -1,0 +1,65 @@
+; Definitions
+
+(package_clause
+  name: (package_identifier) @name) @definition.module
+
+(trait_definition
+  name: (identifier) @name) @definition.interface
+
+(enum_definition
+  name: (identifier) @name) @definition.enum
+
+(simple_enum_case
+  name: (identifier) @name) @definition.class
+
+(full_enum_case
+  name: (identifier) @name) @definition.class
+
+(class_definition
+  name: (identifier) @name) @definition.class
+
+(object_definition
+  name: (identifier) @name) @definition.object
+
+(function_definition
+  name: (identifier) @name) @definition.function
+
+(val_definition
+  pattern: (identifier) @name) @definition.variable
+
+(given_definition
+  name: (identifier) @name) @definition.variable
+
+(var_definition
+  pattern: (identifier) @name) @definition.variable
+
+(val_declaration
+  name: (identifier) @name) @definition.variable
+
+(var_declaration
+  name: (identifier) @name) @definition.variable
+
+(type_definition
+  name: (type_identifier) @name) @definition.type
+
+(class_parameter
+  name: (identifier) @name) @definition.property
+
+; References
+
+(call_expression
+  (identifier) @name) @reference.call
+
+(instance_expression
+  (type_identifier) @name) @reference.interface
+
+(instance_expression
+  (generic_type
+    (type_identifier) @name)) @reference.interface
+
+(extends_clause
+  (type_identifier) @name) @reference.class
+
+(extends_clause
+  (generic_type
+    (type_identifier) @name)) @reference.class


### PR DESCRIPTION
- include package clause and givens in outline
- extract package name and method as Zed env vars
- fix bug where main method with no parameter list is not tagged.

also - latest treesitter grammar (drops symbol_literal)

the new runnables.scm changes enable you to extract the fully qualified name of a class to run it precisely. Previously the only variable available was the builtin `$ZED_FILE` (and `$ZED_SYMBOL` which is only the simple name of the symbol where the `run` is placed)

below a sample `zed/tasks.json`: (see an [explanation](https://gist.github.com/bishabosha/94da5f7b8b0f97589ceb6f5006389915) for the complex shell logic to concatenate package and method name)
```json
[
  {
    "label": "Scala run",
    "command": "scala",
    "args": [
      "run",
      "-M",
      "$(if [ -z \"${ZED_CUSTOM_scala_package_name:}\" ] ; then echo \"$ZED_CUSTOM_scala_main_function_name\"; else echo \"${ZED_CUSTOM_scala_package_name:}.$ZED_CUSTOM_scala_main_function_name\"; fi)",
      "$ZED_WORKTREE_ROOT"
    ],
    "tags": ["scala-main"]
  }
]
```
Edit: note to documentation authors: please use `$ZED_CUSTOM_scala_main_function_name` in tasks, not `$ZED_SYMBOL` - as it will not capture the wrapper object for `def main(args: Array[String])`