### PR TITLE
Add language specific tasks (sbt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Following are example tasks that you can add to your editor, to know more about 
   "label": "Run current test suite with bloop",
   "command": "bloop test $(basename $ZED_WORKTREE_ROOT) -o \"*$ZED_STEM*\"",
   "reveal": "no_focus",
-  "tags": ["scala-test"],
+  "tags": ["scala-test"]
 }
 ```
 

--- a/languages/scala/tasks.json
+++ b/languages/scala/tasks.json
@@ -1,0 +1,29 @@
+[
+  {
+    "label": "sbt clean",
+    "command": "sbt --client clean",
+    "reveal": "no_focus"
+  },
+  {
+    "label": "sbt compile",
+    "command": "sbt --client compile",
+    "reveal": "no_focus"
+  },
+  {
+    "label": "sbt test",
+    "command": "sbt --client test",
+    "reveal": "no_focus"
+  },
+  {
+    "label": "sbt testOnly *$ZED_STEM",
+    "command": "sbt --client 'testOnly *$ZED_STEM'",
+    "reveal": "no_focus",
+    "tags": ["scala-test"]
+  },
+  {
+    "label": "sbt run",
+    "command": "sbt --client run",
+    "reveal": "no_focus",
+    "tags": ["scala-main"]
+  }
+]


### PR DESCRIPTION
Apparently, Zed has supported language-specific tasks for some time (i.e., tasks that don't need to be specified by the user). For Scala, I understand that adding a set of predefined tasks will always be an opinionated choice, but let's start with sbt as it's currently the most used build tool. Any ideas are welcome 🙏

https://zed.dev/blog/zed-decoded-tasks#language-specific-tasks