### PR TITLE
Update wasm to wasip2

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "stable"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
-targets = ["wasm32-wasip1"]
+targets = ["wasm32-wasip2"]


### PR DESCRIPTION
wasip2 is [required](https://crates.io/crates/zed_extension_api/0.7.0) by the zed_extension_api v0.7.0

should fix https://github.com/zed-industries/extensions/actions/runs/21401030526/job/61611808460?pr=4636