### PR TITLE
ci: Automate upgrade of the version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,16 @@ jobs:
           else
             echo "Success: Tag version matches the version in extension.toml."
           fi
+
+  update-extension-version:
+    name: Update Extension Version
+    needs: check-version-match
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: huacnlee/zed-extension-action@v2
+        with:
+          extension-name: scala
+          push-to: scalameta/zed-extensions
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,4 @@ jobs:
           extension-name: scala
           push-to: scalameta/zed-extensions
         env:
-          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
+          COMMITTER_TOKEN: ${{ secrets.SCALAMETA_BOT_GH_TOKEN }}


### PR DESCRIPTION
As @bishabosha mentioned, there is an action which can be used to automatically create PRs to update the Scala extension in the official Zed extensions registry whenever we release a new version.

What needs to be done:

1. Fork `zed-industries/extensions` to `scalameta/zed-extensions`
2. Create a GitHub PAT with repo and workflow scopes
3. Add it as a secret called `COMMITTER_TOKEN` to this repo

Once that's set up, pushing a version tag should take care of the rest.

Here is the GHA: https://github.com/huacnlee/zed-extension-action