### PR TITLE
Update keywords to be @keyword.modifier to improve theme highlighting

### DIFF
--- a/languages/scala/highlights.scm
+++ b/languages/scala/highlights.scm
@@ -146,10 +146,10 @@
 
 ;; keywords
 
-(opaque_modifier) @type.qualifier
-(infix_modifier) @keyword
-(transparent_modifier) @type.qualifier
-(open_modifier) @type.qualifier
+(opaque_modifier) @keyword.modifier
+(infix_modifier) @keyword.modifier
+(transparent_modifier) @keyword.modifier
+(open_modifier) @keyword.modifier
 
 [
   "case"
@@ -194,7 +194,7 @@
   "sealed"
   "private"
   "protected"
-] @type.qualifier
+] @keyword.modifier
 
 (inline_modifier) @label
 


### PR DESCRIPTION
I had some problems with my current theme highlighting in zed. Some of the keywords had a different color than I was expecting. I saw that it is based on the categories from the grammar and found out, that the [nvim treesitter grammar](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/scala/highlights.scm), which seems to have the same origin, marks modifiers as lazy, private etc. as @keyword.modifiers, which is what I would expect.

Here some screenshot for comparison (look at private):

Before:
<img width="802" height="284" alt="image" src="https://github.com/user-attachments/assets/0ea9f6c2-2c29-468a-a7f9-d8aad6442ed2" />

After:
<img width="758" height="296" alt="image" src="https://github.com/user-attachments/assets/fbeb4900-bc95-4691-a4c9-14bbad55a5a3" />

There are maybe more changes which would be interesting, but these bothered me a lot.