### PR TITLE
feat: metals commands as zed tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,43 @@ Both sections need to be set, since Zed doesn't turn on inlay hints by default a
 
 </details>
 
+## Metals build commands
+
+Metals exposes a number of build/project actions that VS Code surfaces in its sidebar (Import build, Run doctor, etc.). Zed's extension API does not let an extension contribute its own command palette entries or sidebar, but these commands are available as **tasks**.
+
+Open the task picker (`task: spawn`, default `cmd-shift-r` on macOS / `ctrl-shift-r` on Linux), type `Metals` to filter, and pick the command you want.
+
+The following tasks are bundled:
+
+- `Metals: Import build`
+- `Metals: Restart build server`
+- `Metals: Connect to build server`
+- `Metals: Disconnect from build server`
+- `Metals: Switch build server`
+- `Metals: Cascade compile`
+- `Metals: Cancel compilation`
+- `Metals: Clean compile`
+- `Metals: Clean and restart build server`
+- `Metals: Reset notifications`
+- `Metals: Generate BSP config`
+- `Metals: Run doctor`
+
+You can bind a hotkey to a specific task in your `keymap.json`, for example:
+
+```json
+[
+  {
+    "context": "Workspace",
+    "bindings": {
+      "cmd-shift-i": ["task::Spawn", { "task_name": "Metals: Import build" }]
+    }
+  }
+]
+```
+
+> [!NOTE]
+> These tasks rely on the same proxy that powers DAP, so they require Metals to be running for the workspace (open a Scala file first) and they do not work when `lsp.metals.binary.arguments` is set in your Zed settings - that disables the proxy. See [Limitations and known problems](#limitations-and-known-problems).
+
 ## Running Tests
 
 The extension supports detecting tests by checking if the test class inherits from specific traits

--- a/languages/scala/tasks.json
+++ b/languages/scala/tasks.json
@@ -25,5 +25,65 @@
     "command": "sbt --client run",
     "reveal": "no_focus",
     "tags": ["scala-main"]
+  },
+  {
+    "label": "Metals: Import build",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" build-import",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Restart build server",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" build-restart",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Connect to build server",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" build-connect",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Disconnect from build server",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" build-disconnect",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Switch build server",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" bsp-switch",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Cascade compile",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" compile-cascade",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Cancel compilation",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" compile-cancel",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Clean compile",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" compile-clean",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Clean and restart build server",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" reset-workspace",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Reset notifications",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" reset-notifications",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Generate BSP config",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" generate-bsp-config",
+    "reveal": "always"
+  },
+  {
+    "label": "Metals: Run doctor",
+    "command": "node \"$HOME/.metals-zed/cmd.mjs\" doctor-run",
+    "reveal": "always"
   }
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,10 +88,17 @@ impl zed::Extension for ScalaExtension {
                 .map_err(|e| format!("Could not mark current workspace as initialized: {e}"))?;
             workspaces.insert(workspace);
 
+            // Embed the task helper so the proxy can write it to `~/.metals-zed/cmd.mjs`.
+            let mut env = worktree.shell_env();
+            env.push((
+                "METALS_ZED_HELPER_CODE".to_string(),
+                include_str!("metals-cmd.mjs").to_string(),
+            ));
+
             Ok(zed::Command {
                 command: zed::node_binary_path()?, // Node is used to start the proxy
                 args,
-                env: worktree.shell_env(),
+                env,
             })
         } else {
             // Start Metals directly, without DAP support

--- a/src/metals-cmd.mjs
+++ b/src/metals-cmd.mjs
@@ -1,0 +1,78 @@
+// Helper installed by the Metals proxy at `~/.metals-zed/cmd.mjs`.
+// Tasks invoke it as `node $HOME/.metals-zed/cmd.mjs <metals-command>`.
+// It looks up the proxy's HTTP port for the current workspace and POSTs
+// `workspace/executeCommand` to dispatch the command.
+//
+// The request is fire-and-forget: the proxy returns 202 as soon as it hands
+// the command off to Metals. Progress and notifications surface in Zed's UI
+// the same way they do when Metals triggers a command on its own.
+
+import { Buffer } from "node:buffer";
+import { readFileSync } from "node:fs";
+import { request } from "node:http";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const cmd = process.argv[2];
+if (!cmd) {
+  console.error("Usage: metals-cmd <command>");
+  process.exit(1);
+}
+
+const workspace = process.cwd().replace(/\/+$/, "");
+const portFile = join(
+  homedir(),
+  ".metals-zed",
+  `${Buffer.from(workspace).toString("hex")}.port`,
+);
+
+let port;
+try {
+  port = Number(readFileSync(portFile, "utf8").trim());
+} catch {
+  console.error(
+    `Could not find the Metals proxy port file at ${portFile}.\n` +
+      `Make sure Metals is running for this workspace (open a Scala file first), and\n` +
+      `that 'lsp.metals.binary.arguments' is not set in your Zed settings - it disables\n` +
+      `the proxy that these tasks rely on.`,
+  );
+  process.exit(1);
+}
+
+const body = JSON.stringify({
+  method: "workspace/executeCommand",
+  params: { command: cmd },
+  fireAndForget: true,
+});
+
+// node:http rather than fetch() so HTTP_PROXY env vars don't intercept us.
+const req = request(
+  {
+    host: "127.0.0.1",
+    port,
+    path: "/",
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(body),
+    },
+  },
+  (res) => {
+    res.on("data", () => {}); // drain so the socket can close
+    res.on("end", () => {
+      if (res.statusCode === 202) {
+        console.log(`Metals: ${cmd} dispatched. Watch Zed for progress.`);
+      } else {
+        console.error(`Metals: ${cmd} - unexpected response ${res.statusCode}`);
+        process.exit(1);
+      }
+    });
+  },
+);
+req.on("error", (e) => {
+  console.error(
+    `Failed to reach the Metals proxy on port ${port}: ${e.code ?? ""} ${e.message}`,
+  );
+  process.exit(1);
+});
+req.end(body);

--- a/src/proxy.mjs
+++ b/src/proxy.mjs
@@ -22,7 +22,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { createServer } from "node:http";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { Transform } from "node:stream";
 import { text } from "node:stream/consumers";
@@ -40,6 +40,12 @@ const args = process.argv.slice(3);
 
 const PROXY_ID = Buffer.from(process.cwd().replace(/\/+$/, "")).toString("hex");
 const PROXY_HTTP_PORT_FILE = join(workdir, "proxy", PROXY_ID);
+// Tasks defined in `languages/scala/tasks.json` invoke a helper from a stable
+// path (Zed's task variables can't resolve the extension dir). The helper code
+// is passed in via env var by the Rust side.
+const HELPER_DIR = join(homedir(), ".metals-zed");
+const HELPER_FILE = join(HELPER_DIR, "cmd.mjs");
+const HELPER_PORT_FILE = join(HELPER_DIR, `${PROXY_ID}.port`);
 const command = process.platform === "win32" ? `"${bin}"` : bin;
 
 const lsp = spawn(command, args, { shell: process.platform === "win32" });
@@ -69,15 +75,43 @@ const server = createServer(async (req, res) => {
     return;
   }
 
+  // Fire-and-forget mode is used by the Metals task helper. It sidesteps
+  // cosmetic post-command exceptions Metals emits when refreshing client
+  // capabilities Zed doesn't implement. DAP omits this flag and gets Metals'
+  // full JSON-RPC response below.
+  if (data.fireAndForget === true) {
+    proxy.send(data.method, data.params);
+    res.statusCode = 202;
+    res.end(JSON.stringify({ accepted: true }));
+    return;
+  }
+
   const result = await proxy.request(data.method, data.params);
   res.statusCode = 200;
   res.setHeader("Content-Type", "application/json");
   res.write(JSON.stringify(result));
   res.end();
-}).listen(HTTP_PORT, () => {
+}).listen(HTTP_PORT, "127.0.0.1", () => {
+  const portStr = server.address().port.toString();
   mkdirSync(dirname(PROXY_HTTP_PORT_FILE), { recursive: true });
-  writeFileSync(PROXY_HTTP_PORT_FILE, server.address().port.toString());
+  writeFileSync(PROXY_HTTP_PORT_FILE, portStr);
+
+  // Mirror the port file to a workspace-independent location so tasks can find it,
+  // and install the helper script there if Rust passed it in.
+  try {
+    mkdirSync(HELPER_DIR, { recursive: true });
+    writeFileSync(HELPER_PORT_FILE, portStr);
+    const helperCode = process.env.METALS_ZED_HELPER_CODE;
+    if (helperCode) {
+      writeFileSync(HELPER_FILE, helperCode);
+    }
+  } catch (err) {
+    process.stderr.write(`Failed to install Metals task helper: ${err}\n`);
+  }
 });
+
+// If Metals dies, drop with it so Zed respawns the whole pair cleanly.
+lsp.on("exit", () => process.exit(0));
 
 export function createLspProxy({
   server: { stdin: serverStdin, stdout: serverStdout, stderr: serverStderr },
@@ -144,6 +178,20 @@ export function createLspProxy({
 
         serverStdin.write(stringify({ jsonrpc: "2.0", id, method, params }));
       });
+    },
+
+    /**
+     * Send a request without waiting for the response. The eventual reply
+     * still arrives on stdout - register a no-op handler so the queue swallows
+     * it instead of forwarding to Zed (which never asked for it).
+     *
+     * @param {string} method
+     * @param {any} params
+     */
+    send(method, params) {
+      const id = nextid();
+      queue.set(id, () => {});
+      serverStdin.write(stringify({ jsonrpc: "2.0", id, method, params }));
     },
 
     cancel(id) {


### PR DESCRIPTION
# Add Metals build commands as Zed tasks

## Summary

Adds 12 Metals build/project commands (Import build, Run doctor, Cascade compile, Restart build server, etc.) to the Scala task picker so users can invoke them from inside Zed instead of editing `build.sbt` to force re-import or opening Metals' browser UI.

Open the task picker (`cmd-shift-r` / `task: spawn`), type `Metals`, pick a command. Tasks can be bound to hotkeys via `keymap.json`.

## How

The extension already runs a small Node.js proxy between Zed and Metals (used by DAP). On startup the proxy now also writes a helper script to `~/.metals-zed/cmd.mjs` and a per-workspace port file. The new tasks call this helper, which POSTs `workspace/executeCommand` with `fireAndForget: true` so the proxy dispatches the command and returns 202 immediately (matching the semantics of Metals' own HTTP UI). DAP omits the flag and keeps its existing wait-and-respond behavior — zero changes in `src/dap.rs`.

Solves https://github.com/scalameta/metals-zed/issues/16

<img width="473" height="422" alt="Screenshot 2026-06-23 at 13 09 34" src="https://github.com/user-attachments/assets/38bfb7e9-4c56-431a-a6ce-14642cd88926" />